### PR TITLE
Add checks to new PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,35 @@
+name: New Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  new-pr:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Git Config
+        run: git config --global url."https://${{ secrets.PAT }}@github.com/".insteadOf ssh://git@github.com/
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  new-pr:
+  lint-and-build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,4 +32,4 @@ jobs:
         run: npm run lint
 
       - name: Build
-        run: npm run build
+        run: npm run build:prod


### PR DESCRIPTION
Adds a GitHub workflow to check new PRs opened on the main branch. The workflow checks that the linting step passes with no errors or warnings and that the production build succeeds.